### PR TITLE
Don't force the return of an action into dispatching a change

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -22,7 +22,9 @@ class Action {
    * @constructor
    */
   dispatch(payload) {
-    Dispatcher.dispatch(this.callback(payload));
+    if (payload) {
+      Dispatcher.dispatch(this.callback(payload));
+    }
   }
 }
 


### PR DESCRIPTION
When the payload is falsy, don't call dispatch with it
