### PR TITLE
Don't force the return of an action into dispatching a change

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -22,7 +22,10 @@ class Action {
    * @constructor
    */
   dispatch(payload) {
-    Dispatcher.dispatch(this.callback(payload));
+    var result = this.callback(payload);
+    if (result) {
+      Dispatcher.dispatch(result);
+    }
   }
 }
 


### PR DESCRIPTION
When the payload result is falsy, don't call dispatch with it
