### PR TITLE
use storeDidChange as change listener for the store mixin if available, ...

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -23,10 +23,17 @@ class Store {
     assign(this, EventEmitter.prototype, methods);
     this.mixin = {
       componentDidMount: function() {
-        self.addChangeListener(this.onChange);
+        var warn = (console.warn || console.log).bind(console);
+        if(!this.storeDidChange){
+            warn("A component that uses a McFly Store mixin is not implementing\
+                  storeDidChange. onChange will be called instead, but this will\
+                  no longer be supported from version 1.0.");
+        }
+
+        self.addChangeListener(this.storeDidChange || this.onChange);
       },
       componentWillUnmount: function() {
-        self.removeChangeListener(this.onChange);
+        self.removeChangeListener(this.storeDidChange || this.onChange);
       }
     }
   }


### PR DESCRIPTION
...otherwise warn, and use onChange.

This pull request is a proposed implementation for issue #19; if a component implements storeDidChange that is used as the mixin's callback, otherwise, onChange is used, and a warning message is logged on the console. 