### PR TITLE
[feature request] Some syntactical sugar

### DIFF
--- a/dist/McFly.js
+++ b/dist/McFly.js
@@ -1,28 +1,5 @@
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.McFly=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 module.exports = require('./lib/McFly');
-
-var mcFly = new module.exports();
-
-var store = mcFly.createStore({
-
-},
-{
-  ADD_TODO: function(payload){
-    return this;
-  },
-  FOO_BAR_BAZ: function(payload){
-    return this;
-  },
-  WAY_TO_GO: function(payload){
-    return this;
-  },
-});
-
-console.log('boo', store.callback({actionType: 'FKSDF'}));
-console.log('boo', store.callback({actionType: 'WAY_TO_GO'}));
-console.log('boo', store.callback({actionType: 'FKSDF'}));
-console.log('boo', store.callback({actionType: 'FKSDF'}));
-console.log('boo', store.callback({actionType: 'FKSDF'}));
 },{"./lib/McFly":5}],2:[function(require,module,exports){
 var Dispatcher = require('./Dispatcher');
 var Promise = require('es6-promise').Promise;

--- a/dist/McFly.js
+++ b/dist/McFly.js
@@ -164,10 +164,17 @@ var invariant = require('invariant');
     assign(this, EventEmitter.prototype, methods);
     this.mixin = {
       componentDidMount: function() {
-        self.addChangeListener(this.onChange);
+        var warn = (console.warn || console.log).bind(console);
+        if(!this.storeDidChange){
+            warn("A component that uses a McFly Store mixin is not implementing\
+                  storeDidChange. onChange will be called instead, but this will\
+                  no longer be supported from version 1.0.");
+        }
+
+        self.addChangeListener(this.storeDidChange || this.onChange);
       },
       componentWillUnmount: function() {
-        self.removeChangeListener(this.onChange);
+        self.removeChangeListener(this.storeDidChange || this.onChange);
       }
     }
   }
@@ -582,7 +589,7 @@ process.chdir = function (dir) {
  * @copyright Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors (Conversion to ES6 API by Jake Archibald)
  * @license   Licensed under MIT license
  *            See https://raw.githubusercontent.com/jakearchibald/es6-promise/master/LICENSE
- * @version   2.0.0
+ * @version   2.0.1
  */
 
 (function() {
@@ -1213,13 +1220,11 @@ process.chdir = function (dir) {
 
       @class Promise
       @param {function} resolver
-      @param {String} label optional string for labeling the promise.
       Useful for tooling.
       @constructor
     */
-    function $$es6$promise$promise$$Promise(resolver, label) {
+    function $$es6$promise$promise$$Promise(resolver) {
       this._id = $$es6$promise$promise$$counter++;
-      this._label = label;
       this._state = undefined;
       this._result = undefined;
       this._subscribers = [];
@@ -1435,11 +1440,10 @@ process.chdir = function (dir) {
       @method then
       @param {Function} onFulfilled
       @param {Function} onRejected
-      @param {String} label optional string for labeling the promise.
       Useful for tooling.
       @return {Promise}
     */
-      then: function(onFulfillment, onRejection, label) {
+      then: function(onFulfillment, onRejection) {
         var parent = this;
         var state = parent._state;
 
@@ -1447,9 +1451,7 @@ process.chdir = function (dir) {
           return this;
         }
 
-        parent._onerror = null;
-
-        var child = new this.constructor($$$internal$$noop, label);
+        var child = new this.constructor($$$internal$$noop);
         var result = parent._result;
 
         if (state) {
@@ -1488,12 +1490,11 @@ process.chdir = function (dir) {
 
       @method catch
       @param {Function} onRejection
-      @param {String} label optional string for labeling the promise.
       Useful for tooling.
       @return {Promise}
     */
-      'catch': function(onRejection, label) {
-        return this.then(null, onRejection, label);
+      'catch': function(onRejection) {
+        return this.then(null, onRejection);
       }
     };
 
@@ -1530,8 +1531,8 @@ process.chdir = function (dir) {
     };
 
     var es6$promise$umd$$ES6Promise = {
-      Promise: $$es6$promise$promise$$default,
-      polyfill: $$es6$promise$polyfill$$default
+      'Promise': $$es6$promise$promise$$default,
+      'polyfill': $$es6$promise$polyfill$$default
     };
 
     /* global define:true module:true window: true */

--- a/src/Action.js
+++ b/src/Action.js
@@ -1,10 +1,45 @@
 var Dispatcher = require('./Dispatcher');
 var Promise = require('es6-promise').Promise;
 
+var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
+
+function callbackToPromise(func) {
+  var fnStr = func.toString().replace(STRIP_COMMENTS, '');
+  var args = fnStr.slice(fnStr.indexOf('(')+1, fnStr.indexOf(')'));
+  
+  if ((/^\s*?\$done/i).test(args)) {
+    return function () {
+      var _self = this, _args = Array.prototype.slice.call(arguments);
+      return new Promise(function(resolve, reject){
+        var done = function $done(err, result) {
+          if (err) return reject(err);
+          return resolve(result);
+        };
+
+        _args.unshift(done);
+        func.apply(_self, _args);
+      });
+    };
+  }
+
+  return func;
+}
 
 function reThrow(reject, error) {
   setTimeout(function(){ throw error; }, 0);
   return reject();
+}
+
+function dispatchPayload(payload) {
+  console.log('dispatched!', payload)
+  return new Promise(function(resolve, reject){
+    if (!payload) return reject();
+    if (!payload.actionType) return reThrow(reject,
+      "Payload object requires an actionType property"
+    );
+    Dispatcher.dispatch(payload);
+    resolve();
+  });
 }
 
 /**
@@ -19,7 +54,7 @@ class Action {
    * @constructor
    */
   constructor(callback) {
-    this.callback = callback;
+    this.callback = callbackToPromise(callback);
   }
 
   /**
@@ -30,16 +65,7 @@ class Action {
    */
   dispatch() {
     return Promise.resolve(this.callback.apply(this, arguments))
-      .then(function(payload){
-        return new Promise(function(resolve, reject){
-          if (!payload) return reject();
-          if (!payload.actionType) return reThrow(reject,
-            "Payload object requires an actionType property"
-          );
-          Dispatcher.dispatch(payload)
-          resolve();
-        });
-      });
+      .then(dispatchPayload);
   }
 }
 

--- a/src/Store.js
+++ b/src/Store.js
@@ -20,7 +20,7 @@ class Store {
     this.callback = callback;
     invariant(!methods.callback, '"callback" is a reserved name and cannot be used as a method name.');
     invariant(!methods.mixin,'"mixin" is a reserved name and cannot be used as a method name.');
-    assign(this, EventEmitter.prototype, methods);
+    assign(this, new EventEmitter(), methods);
     this.mixin = {
       componentDidMount: function() {
         var warn = (console.warn || console.log).bind(console);
@@ -35,7 +35,7 @@ class Store {
       componentWillUnmount: function() {
         self.removeChangeListener(this.storeDidChange || this.onChange);
       }
-    }
+    };
   }
 
   /**


### PR DESCRIPTION
I've customized McFly a bit and decided to update my fork. I'll document and write tests if anyone is interested.

`McFly.createStore` can accept an object as it's second argument to
compile a payload listening callback. The `Action` class now accepts a
callback with the first argument as `$done` (experimental) as an alternative to
returning promises for deferring payload data, if `$done` is not found as the first argument the callback is run synchronously.

Examples:
```javascript
var McFly = require('mcfly');
var invariant = require('invariant');

var mcFly = new McFly();

var actions = mcFly.createActions({

  /**
   * Use $done as first argument
   */
  addTodo: function($done, title, description){
    setTimeout(function () {
      // do stuff ...
      $done(null, {
        actionType: 'ADD_TODO',
        title: title,
        description: description
      });
    }, 1000);
  }

});

var store = mcFly.createStore({

  addTodo: function(item, description){
    invariant(item === 'IM A TITLE');
    invariant(description === 'IM THE DESCRIPTION');
  }

},
{
  ADD_TODO: function(payload){
    invariant(payload.actionType === 'ADD_TODO');
    this.addTodo(payload.item, payload.description);
    this.emitChange();

    return true;
  }
});

// Manually call an action
invariant(actions.addTodo('IM A TITLE', 'IM THE DESCRIPTION') === true);
```

EDIT: fixed an error