### PR TITLE
check unmounted before component mixin onChange listener is invoked

### DIFF
--- a/dist/McFly.js
+++ b/dist/McFly.js
@@ -194,7 +194,9 @@ var iv = require('invariant');
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(function(){return ( this.$Store_lifeCycleState != "UNMOUNTED" ) && this.listener();}.bind(this));
+        this.listener && self.addChangeListener(function(){
+          this.isMounted() && this.listener();
+        }.bind(this));
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/dist/McFly.js
+++ b/dist/McFly.js
@@ -194,7 +194,7 @@ var iv = require('invariant');
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(this.listener);
+        this.listener && self.addChangeListener(function(){return ( this.$Store_lifeCycleState != "UNMOUNTED" ) && this.listener();}.bind(this));
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/dist/McFly.js
+++ b/dist/McFly.js
@@ -186,17 +186,17 @@ var iv = require('invariant');
     assign(this, EventEmitter.prototype, methods);
     this.mixin = {
       componentDidMount: function() {
-        var warn = (console.warn || console.log).bind(console);
+        var warn = (console.warn || console.log).bind(console),
+          changeFn;
         if(!this.storeDidChange){
             warn("A component that uses a McFly Store mixin is not implementing storeDidChange. onChange will be called instead, but this will no longer be supported from version 1.0.");
         }
-        this.listener = this.storeDidChange || this.onChange;
-        if(!this.listener){
+        changeFn = this.storeDidChange || this.onChange;
+        if(!changeFn){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(function(){
-          this.isMounted() && this.listener();
-        }.bind(this));
+        this.listener = function(){ this.isMounted() && changeFn(); }.bind(this)
+        self.addChangeListener(this.listener);
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -33,7 +33,9 @@ var iv = require('invariant');
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(function(){return ( this.$Store_lifeCycleState != "UNMOUNTED" ) && this.listener();}.bind(this));
+        this.listener && self.addChangeListener(function(){
+          this.isMounted() && this.listener();
+        }.bind(this));
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -33,7 +33,7 @@ var iv = require('invariant');
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(this.listener);
+        this.listener && self.addChangeListener(function(){return ( this.$Store_lifeCycleState != "UNMOUNTED" ) && this.listener();}.bind(this));
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -25,17 +25,17 @@ var iv = require('invariant');
     assign(this, EventEmitter.prototype, methods);
     this.mixin = {
       componentDidMount: function() {
-        var warn = (console.warn || console.log).bind(console);
+        var warn = (console.warn || console.log).bind(console),
+          changeFn;
         if(!this.storeDidChange){
             warn("A component that uses a McFly Store mixin is not implementing storeDidChange. onChange will be called instead, but this will no longer be supported from version 1.0.");
         }
-        this.listener = this.storeDidChange || this.onChange;
-        if(!this.listener){
+        changeFn = this.storeDidChange || this.onChange;
+        if(!changeFn){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(function(){
-          this.isMounted() && this.listener();
-        }.bind(this));
+        this.listener = function(){ this.isMounted() && changeFn(); }.bind(this)
+        self.addChangeListener(this.listener);
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/src/Store.js
+++ b/src/Store.js
@@ -33,7 +33,7 @@ class Store {
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(this.listener);
+        this.listener && self.addChangeListener(()=>( this._lifeCycleState != "UNMOUNTED" ) && this.listener());
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/src/Store.js
+++ b/src/Store.js
@@ -33,7 +33,9 @@ class Store {
         if(!this.listener){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(()=>( this._lifeCycleState != "UNMOUNTED" ) && this.listener());
+        this.listener && self.addChangeListener(()=>{
+          this.isMounted() && this.listener();
+        });
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);

--- a/src/Store.js
+++ b/src/Store.js
@@ -25,17 +25,17 @@ class Store {
     assign(this, EventEmitter.prototype, methods);
     this.mixin = {
       componentDidMount: function() {
-        var warn = (console.warn || console.log).bind(console);
+        var warn = (console.warn || console.log).bind(console),
+          changeFn;
         if(!this.storeDidChange){
             warn("A component that uses a McFly Store mixin is not implementing storeDidChange. onChange will be called instead, but this will no longer be supported from version 1.0.");
         }
-        this.listener = this.storeDidChange || this.onChange;
-        if(!this.listener){
+        changeFn = this.storeDidChange || this.onChange;
+        if(!changeFn){
             warn("A change handler is missing from a component with a McFly mixin. Notifications from Stores are not being handled.");
         }
-        this.listener && self.addChangeListener(()=>{
-          this.isMounted() && this.listener();
-        });
+        this.listener = ()=>{ this.isMounted() && changeFn(); }
+        self.addChangeListener(this.listener);
       },
       componentWillUnmount: function() {
         this.listener && self.removeChangeListener(this.listener);


### PR DESCRIPTION
dirty fix for: https://github.com/kenwheeler/mcfly/issues/30

It seems like the listener was still being invoked after the removeChangeListener was called because the listener had already been placed on the event queue at the moment emitChange was called. 

I.e.
1. emitChange fired
2. all listeners queued up
3. one event un-mounts component and calls removesListener
4. EventEmitter calls next listeners on emitChange queue still
5. once all listeners have been invoked
6. the removeListener is actually applied.

Maybe...

Some component change listeners may still want to be invoked when the component isn't mounted... this prevents that :-1: - another solution could be to have the storeDidMount methods give a return value of the newState and then we can perform the lifeCycle check around any replaceState calls.