### PR TITLE
Remove 'return true;'s from dispatcher callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ getTodos: function() {
 }
 
 }, function(payload){
+  var needsUpdate = false;
 
   switch(payload.actionType) {
   case 'ADD_TODO':
     addTodo(payload.text);
-  break;
-  default:
-    return true;
+    needsUpdate = true;
+    break;
   }
 
-  TodoStore.emitChange();
-
-  return true;
+  if (needsUpdate) {
+    TodoStore.emitChange();
+  }
 
 });
 ```

--- a/example/js/stores/CounterStore.js
+++ b/example/js/stores/CounterStore.js
@@ -13,18 +13,18 @@ var CounterStore = mcFly.createStore({
   }
 
 }, function(payload){
+  var needsUpdate = false;
 
   switch(payload.actionType) {
     case 'COUNT_ONE':
       countOne();
-    break;
-    default:
-      return true;
+      needsUpdate = true;
+      break;
   }
 
-  CounterStore.emitChange();
-
-  return true;
+  if (needsUpdate) {
+    CounterStore.emitChange();
+  }
 
 });
 


### PR DESCRIPTION
The dispatcher released by Facebook no longer uses promises and doesn't use the return value of registered stores' dispatcher callbacks.

See https://github.com/facebook/flux/blob/master/src/Dispatcher.js#L217 and https://github.com/facebook/flux/blob/master/examples/flux-chat/js/stores/MessageStore.js#L96-127 for some Facebook evidence that this is no longer necessary (unfortunately they haven't been keeping the flux tutorial up-to-date).

I favor single exit points for functions when it's not too much trouble, so I added a needsUpdate variable to keep track of whether the store should emit change. Alternatively, the emitChange() calls could be moved up into the case statements or you could simply return in the default.