### PR TITLE
Add a test to check that payloads are digested correctly

### DIFF
--- a/src/__tests__/McFly-test.js
+++ b/src/__tests__/McFly-test.js
@@ -3,6 +3,7 @@
 jest.dontMock('../McFly');
 jest.dontMock('../Store');
 jest.dontMock('../ActionsFactory');
+jest.dontMock('../Action');
 jest.dontMock('../Dispatcher');
 jest.dontMock('object-assign');
 
@@ -91,6 +92,20 @@ describe('McFly', function() {
   it('should store created ActionsFactory methods in an actions property', function() {
 
     expect("add" in mcFly.actions).toEqual(true);
+
+  });
+
+  pit('should digest the correct payload in the store when it is dispatched', function() {
+
+    var testItem = 'test';
+    return mockActionsFactory.add(testItem)
+      .then(function() {
+        expect(mockStore.getItems()).toEqual([testItem]);
+      }).then(function() {
+        return mockActionsFactory.remove(testItem);
+      }).then(function() {
+        expect(mockStore.getItems()).toEqual([]);
+      });
 
   });
 

--- a/src/__tests__/McFly-test.js
+++ b/src/__tests__/McFly-test.js
@@ -13,7 +13,20 @@ describe('McFly', function() {
   var ActionsFactory = require('../ActionsFactory');
   var mcFly,mockStore,mockActionsFactory;
 
-  mcFly = new McFly();
+  beforeEach(function() {
+
+    mcFly = new McFly();
+    mockStore = mcFly.createStore({testMethod: function(){}}, function(){});
+    mockActionsFactory = mcFly.createActions({
+      testMethod: function(test) {
+        return {
+          actionType: 'TEST_ADD',
+          data: test
+        }
+      }
+    });
+
+  });
 
   it('should instantiate a new dispatcher and attach it to the new instance', function() {
 
@@ -22,8 +35,6 @@ describe('McFly', function() {
   });
 
   it('should create a new Store when createStore is called', function() {
-
-    mockStore = mcFly.createStore({testMethod: function(){}}, function(){});
 
     expect(mockStore instanceof Store).toEqual(true);
 
@@ -37,20 +48,11 @@ describe('McFly', function() {
 
   it('should register created Stores with the Dispatcher and store the token', function() {
 
-    expect(mockStore.getDispatchToken()).toEqual("ID_1");
+    expect(mockStore.getDispatchToken()).toMatch(/ID_\d+/);
 
   });
 
   it('should create a new ActionsFactory when createActions is called', function() {
-
-    mockActionsFactory = mcFly.createActions({
-      testMethod: function(test) {
-        return {
-          actionType: 'TEST_ADD',
-          data: test
-        }
-      }
-    });
 
     expect(mockActionsFactory instanceof ActionsFactory).toEqual(true);
 

--- a/src/__tests__/McFly-test.js
+++ b/src/__tests__/McFly-test.js
@@ -11,17 +11,47 @@ describe('McFly', function() {
   var McFly = require('../McFly');
   var Store = require('../Store');
   var ActionsFactory = require('../ActionsFactory');
-  var mcFly,mockStore,mockActionsFactory;
+  var TestConstants = {
+    TEST_ADD: 'TEST_ADD',
+    TEST_REMOVE: 'TEST_REMOVE'
+  };
+
+  var mcFly,mockStore,mockActionsFactory,testItems;
 
   beforeEach(function() {
 
     mcFly = new McFly();
-    mockStore = mcFly.createStore({testMethod: function(){}}, function(){});
+
+    var items = [];
+    mockStore = mcFly.createStore(
+    {
+      getItems: function() {
+        return items;
+      }
+    }, function(payload) {
+      switch(payload.actionType) {
+        case TestConstants.TEST_ADD:
+          items.push(payload.item);
+        break;
+        case TestConstants.TEST_REMOVE:
+          items.splice(items.indexOf(payload.item), 1);
+        break;
+        default:
+          return true;
+      }
+    });
+
     mockActionsFactory = mcFly.createActions({
-      testMethod: function(test) {
+      add: function(item) {
         return {
-          actionType: 'TEST_ADD',
-          data: test
+          actionType: TestConstants.TEST_ADD,
+          item: item
+        }
+      },
+      remove: function(item) {
+        return {
+          actionType: TestConstants.TEST_REMOVE,
+          item: item
         }
       }
     });
@@ -60,7 +90,7 @@ describe('McFly', function() {
 
   it('should store created ActionsFactory methods in an actions property', function() {
 
-    expect("testMethod" in mcFly.actions).toEqual(true);
+    expect("add" in mcFly.actions).toEqual(true);
 
   });
 


### PR DESCRIPTION
This allows us to refactor/change the API for issues like https://github.com/kenwheeler/mcfly/issues/4 without worrying about introducing regressions.